### PR TITLE
Improve performance of Julia code by 2-30x

### DIFF
--- a/code/Julia/KronGraph500NoPerm.jl
+++ b/code/Julia/KronGraph500NoPerm.jl
@@ -1,6 +1,6 @@
 function KronGraph500NoPerm(SCALE,EdgesPerVertex)
 #
-#Graph500NoPerm: Generates graph edges using the same 2x2 Kronecker algorithm (R-MAT) as the Graph500 benchmark, 
+#Graph500NoPerm: Generates graph edges using the same 2x2 Kronecker algorithm (R-MAT) as the Graph500 benchmark,
 #                but no permutation of vertex labels is performed.
 #IO user function.
 #  Usage:
@@ -11,28 +11,34 @@ function KronGraph500NoPerm(SCALE,EdgesPerVertex)
 # Outputs:
 #    StartVertex = Mx1 vector of integer start vertices in the range [1,N]
 #    EndVertex = Mx1 vector of integer end vertices in the range [1,N]
-  
-  N = 2.^SCALE;                       # Set  power of number of vertices..
 
-  M = round(Int, EdgesPerVertex .* N);     # Compute total number of edges to generate.
+  N = 2.^SCALE                       # Set  power of number of vertices..
 
-  A = 0.57; B = 0.19;  C = 0.19;   D = 1-(A+B+C);  # Set R-MAT (2x2 Kronecker) coefficeints.
- 
-  ij = ones(2, M);            # Initialize index arrays.
-  ab = A + B;                 # Normalize coefficients.
-  c_norm = C/(1 - (A + B));
-  a_norm = A/(A + B);
+  M = round(Int, EdgesPerVertex .* N)     # Compute total number of edges to generate.
 
-  for ib = 1:SCALE            # Loop over each scale.
-    ii_bit = falses(1,M);
-    setindex!(ii_bit,true,find(rand(1, M) .> ab));
-    jj_bit = falses(1,M);
-    setindex!(jj_bit,true,find(rand(1, M) .> ( c_norm * ii_bit + a_norm * !(ii_bit) )) );
-    ij = ij + 2^(ib-1) * [ii_bit; jj_bit];
+  A = 0.57; B = 0.19;  C = 0.19;   D = 1-(A+B+C)  # Set R-MAT (2x2 Kronecker) coefficients.
+
+  ij = ones(Int, 2, M)         # Initialize index arrays.
+  ab = A + B                 # Normalize coefficients.
+  c_norm = C/(1 - (A + B))
+  a_norm = A/(A + B)
+
+  for j = 1:M
+      for ib = 1:SCALE            # Loop over each scale.
+          k = 1 << (ib-1)
+          if rand() > ab
+              ij[1,j] += k
+              if rand() > c_norm
+                  ij[2,j] += k
+              end
+          elseif rand() > a_norm
+              ij[2,j] += k
+          end
+      end
   end
 
-  StartVertex = ij[1,:];     # Copy to output. (row vector)
-  EndVertex = ij[2,:];       # Copy to output. (row vector)
+  StartVertex = sub(ij,1,:)     # Copy to output. (row vector)
+  EndVertex =   sub(ij,2,:)       # Copy to output. (row vector)
 
-  return StartVertex,EndVertex;
+  return StartVertex,EndVertex
 end

--- a/code/Julia/PageRankPipeline.jl
+++ b/code/Julia/PageRankPipeline.jl
@@ -9,7 +9,7 @@ function PageRankPipeline(SCALE,EdgesPerVertex,Nfile);
   M = EdgesPerVertex .* Nmax;                # Total number of edges.
   myFiles = collect(1:Nfile).';              # Set list of files.
   #
-  # Julia parallel verison 
+  # Julia parallel verison
   # Figure it out later: how to distribute the load
   # myFiles = global_ind(zeros(Nfile,1,map([Np 1],{},0:Np-1)));   # PARALLEL.
   tab = Char(9);
@@ -31,7 +31,7 @@ function PageRankPipeline(SCALE,EdgesPerVertex,Nfile);
       println("  Writing: " * fname);                          # Read filename.
       srand(i);                                                # Set random seed to be unique for this file.
       u, v = KronGraph500NoPerm(SCALE,EdgesPerVertex./Nfile);  # Generate data.
-	  
+
       edgeStr = string(round(Int64,[u'; v']'));                        # Convert edges to strings in (u,v) pairs
       edgeStr = replace(edgeStr,r"\[|\]|\n","");               # Remove extra chars ([, ], \n).
       StrFileWrite(edgeStr,fname);                             # Write string to file.
@@ -64,7 +64,7 @@ function PageRankPipeline(SCALE,EdgesPerVertex,Nfile);
     sortIndex = sortperm(vec(u));                      # Sort starting vertices.
     u = u[sortIndex];                                  # Get starting vertices.
     v = v[sortIndex];                                  # Get ending vertices.
-  
+
   K1time1 = toq();
   tic();
     # Write all the data to files.
@@ -76,7 +76,7 @@ function PageRankPipeline(SCALE,EdgesPerVertex,Nfile);
       vv = v[jEdgeStart:jEdgeEnd];                                 # Select end vertices.
       fname = "data/K1/" * string(i) * ".tsv";
       println("  Writing: " * fname);                              # Create filename.
-	  
+
       edgeStr = string(round(Int64,[uu'; vv']'));                  # Convert edges to strings in (u,v) pairs
       edgeStr = replace(edgeStr,r"\[|\]|\n","");                   # Remove extra chars ([, ], \n).
       StrFileWrite(edgeStr,fname);                                   # uu,vv: row vector
@@ -135,7 +135,7 @@ function PageRankPipeline(SCALE,EdgesPerVertex,Nfile);
     a = (1-c) ./ Nmax;                    # Create damping vector
 
     for i=1:Niter
-      r = ((c .* r) * A) + (a .* sum(r,2));                # Compute PageRank.
+        r = ((c .* r) * A) .+ (a .* sum(r,2));                # Compute PageRank.
     end
 
     r=r./norm(r,1);
@@ -156,5 +156,3 @@ end
 ########################################################
 # (c) <2015> Massachusetts Institute of Technology
 ########################################################
-
-

--- a/code/Julia/PageRankPipeline.jl
+++ b/code/Julia/PageRankPipeline.jl
@@ -9,7 +9,7 @@ function PageRankPipeline(SCALE,EdgesPerVertex,Nfile);
   M = EdgesPerVertex .* Nmax;                # Total number of edges.
   myFiles = collect(1:Nfile).';              # Set list of files.
   #
-  # Julia parallel verison
+  # Julia parallel version
   # Figure it out later: how to distribute the load
   # myFiles = global_ind(zeros(Nfile,1,map([Np 1],{},0:Np-1)));   # PARALLEL.
   tab = Char(9);

--- a/code/Julia/PageRankPipeline.jl
+++ b/code/Julia/PageRankPipeline.jl
@@ -135,7 +135,9 @@ function PageRankPipeline(SCALE,EdgesPerVertex,Nfile);
     a = (1-c) ./ Nmax;                    # Create damping vector
 
     for i=1:Niter
-        r = (c .* (r * A)) .+ (a .* sum(r,2));                # Compute PageRank.
+        s = r * A
+        scale!(s, c)
+        r = s .+ (a * sum(r,2));                # Compute PageRank.
     end
 
     r=r./norm(r,1);

--- a/code/Julia/PageRankPipeline.jl
+++ b/code/Julia/PageRankPipeline.jl
@@ -91,7 +91,6 @@ function PageRankPipeline(SCALE,EdgesPerVertex,Nfile);
   ########################################################
   println("Kernel 2: Read, Filter Edges");
   tic();
-
     # Read in all the files into one array.
     for i in myFiles
       fname = "data/K1/" * string(i) * ".tsv";
@@ -105,17 +104,17 @@ function PageRankPipeline(SCALE,EdgesPerVertex,Nfile);
     end
 
     # Construct adjacency matrix.
-    A = sparse(round(Int64,vec(u)),round(Int64,vec(v)),1,Nmax,Nmax); # Create adjacency matrix.
+    A = sparse(vec(u),vec(v),1.0,Nmax,Nmax)      # Create adjacency matrix.
 
     # Filter and weight the adjacency matrix.
-    din = sum(A,1);                              # Compute in degree.
-    setindex!(A,0,find(din == maximum(din)))     # Eliminate the super-node.
-    setindex!(A,0,find(din == 1))                # Eliminate the leaf-node.
-    dout = sum(A,2);                             # Compute the out degree.
-    i = find(dout);                              # Find vertices with outgoing edges (dout > 0).
-    DoutInv = sparse(i,i,1./dout[i],Nmax,Nmax);  # Create diagonal weight matrix.
-    A = DoutInv * A;                             # Apply weight matrix.
-
+    din = sum(A,1)                               # Compute in degree.
+    A[find(din == maximum(din))]=0               # Eliminate the super-node.
+    A[find(din == 1)]=0                          # Eliminate the leaf-node.
+    dout = sum(A,2)                              # Compute the out degree.
+    i = find(dout)                               # Find vertices with outgoing edges (dout > 0).
+    DoutInvD = zeros(Nmax)        # Create diagonal weight matrix.
+    DoutInvD[i] = 1./dout[i]
+    scale!(DoutInvD, A)           # Apply weight matrix.
   K2time = toq();
   println("K2 Time: " * string(K2time) * ", Edges/sec: " * string(M./K2time));
 

--- a/code/Julia/PageRankPipeline.jl
+++ b/code/Julia/PageRankPipeline.jl
@@ -135,7 +135,7 @@ function PageRankPipeline(SCALE,EdgesPerVertex,Nfile);
     a = (1-c) ./ Nmax;                    # Create damping vector
 
     for i=1:Niter
-        r = ((c .* r) * A) .+ (a .* sum(r,2));                # Compute PageRank.
+        r = (c .* (r * A)) .+ (a .* sum(r,2));                # Compute PageRank.
     end
 
     r=r./norm(r,1);

--- a/code/Julia/PageRankPipeline.jl
+++ b/code/Julia/PageRankPipeline.jl
@@ -12,10 +12,10 @@ function PageRankPipeline(SCALE,EdgesPerVertex,Nfile);
   # Julia parallel version
   # Figure it out later: how to distribute the load
   # myFiles = global_ind(zeros(Nfile,1,map([Np 1],{},0:Np-1)));   # PARALLEL.
-  tab = Char(9);
-  nl = Char(10);
-  Niter = 20;                                      # Number of PageRank iterations.
-  c = 0.15;                                        # PageRank damping factor.
+  tab = Char(9)
+  nl = Char(10)
+  Niter = 20                                      # Number of PageRank iterations.
+  c = 0.15                                        # PageRank damping factor.
 
   println("Number of Edges: " * string(M) * ", Maximum Possible Vertex: " * string(Nmax));
 
@@ -25,19 +25,28 @@ function PageRankPipeline(SCALE,EdgesPerVertex,Nfile);
   ########################################################
   println("Kernel 0: Generate Graph, Write Edges");
   tic();
-
     for i in myFiles
       fname = "data/K0/" * string(i) * ".tsv";
       println("  Writing: " * fname);                          # Read filename.
       srand(i);                                                # Set random seed to be unique for this file.
       u, v = KronGraph500NoPerm(SCALE,EdgesPerVertex./Nfile);  # Generate data.
 
-      edgeStr = string(round(Int64,[u'; v']'));                        # Convert edges to strings in (u,v) pairs
-      edgeStr = replace(edgeStr,r"\[|\]|\n","");               # Remove extra chars ([, ], \n).
-      StrFileWrite(edgeStr,fname);                             # Write string to file.
+      n = length(u)
+      f = IOBuffer()#20n)
+      for j in 1:n-1
+           write(f, string(u[j]))
+           write(f, ' ')
+           write(f, string(v[j]))
+           write(f, ' ')
+      end
+      write(f, string(u[n]))
+      write(f, ' ')
+      write(f, string(v[n]))
 
+      open(fname, "w") do g
+          write(g, takebuf_string(f))
+      end
     end
-
   K0time = toq();
   println("K0 Time: " * string(K0time) * ", Edges/sec: " * string(M./K0time));
 

--- a/code/Julia/PageRankPipeline.jl
+++ b/code/Julia/PageRankPipeline.jl
@@ -65,17 +65,18 @@ function PageRankPipeline(SCALE,EdgesPerVertex,Nfile);
   tic();
     # Write all the data to files.
     j = 1;                                                         # Initialize file counter.
+    c = size(u,1)/length(myFiles)        # Compute first edge of file.
     for i in myFiles
-      jEdgeStart = round(Int64,((j-1).*(size(u,1)./length(myFiles))+1));        # Compute first edge of file.
-      jEdgeEnd = round(Int64,((j).*(size(u,1)./length(myFiles))));              # Compute last edge of file.
+      jEdgeStart = round(Int, (j-1)*c+1)# Compute first edge of file.
+      jEdgeEnd = round(Int, j*c)          # Compute last edge of file.
       uu = sub(u,jEdgeStart:jEdgeEnd)                                 # Select start vertices.
       vv = sub(v,jEdgeStart:jEdgeEnd)                                 # Select end vertices.
-      fname = "data/K1/" * string(i) * ".tsv";
-      println("  Writing: " * fname);                              # Create filename.
+      fname = "data/K1/" * string(i) * ".tsv"
+      println("  Writing: " * fname)                              # Create filename.
 
       writeuv(fname, uu, vv)
 
-      j = j + 1;                                                   # Increment file counter.
+      j = j + 1                                                   # Increment file counter.
     end
 
   K1time2 = toq();

--- a/code/Julia/PageRankPipeline.jl
+++ b/code/Julia/PageRankPipeline.jl
@@ -29,9 +29,9 @@ function PageRankPipeline(SCALE,EdgesPerVertex,Nfile);
       fname = "data/K0/" * string(i) * ".tsv";
       println("  Writing: " * fname);                          # Read filename.
       srand(i);                                                # Set random seed to be unique for this file.
-      u, v = KronGraph500NoPerm(SCALE,EdgesPerVertex./Nfile);  # Generate data.
+      ut, vt = KronGraph500NoPerm(SCALE,EdgesPerVertex./Nfile);  # Generate data.
 
-      writeuv(fname, u, v)
+      writeuv(fname, ut, vt)
     end
   K0time = toq();
   println("K0 Time: " * string(K0time) * ", Edges/sec: " * string(M./K0time));
@@ -113,9 +113,9 @@ function PageRankPipeline(SCALE,EdgesPerVertex,Nfile);
     A[find(din == maximum(din))]=0               # Eliminate the super-node.
     A[find(din == 1)]=0                          # Eliminate the leaf-node.
     dout = sum(A,2)                              # Compute the out degree.
-    i = find(dout)                               # Find vertices with outgoing edges (dout > 0).
+    is = find(dout)                               # Find vertices with outgoing edges (dout > 0).
     DoutInvD = zeros(Nmax)        # Create diagonal weight matrix.
-    DoutInvD[i] = 1./dout[i]
+    DoutInvD[is] = 1./dout[is]
     scale!(DoutInvD, A)           # Apply weight matrix.
   K2time = toq();
   println("K2 Time: " * string(K2time) * ", Edges/sec: " * string(M./K2time));

--- a/code/Julia/PageRankPipeline.jl
+++ b/code/Julia/PageRankPipeline.jl
@@ -99,7 +99,9 @@ function PageRankPipeline(SCALE,EdgesPerVertex,Nfile);
       if i == 1
          u = ut; v = vt;                             # Initialize starting and ending vertices.
       else
-         u = hcat(u,ut); v = hcat(v,vt);             # Get the rest of starting and ending vertices.
+         append!(u, ut)
+         append!(v, vt)
+         # Get the rest of starting and ending vertices.
       end
     end
 

--- a/code/Julia/StrFileRead.jl
+++ b/code/Julia/StrFileRead.jl
@@ -2,13 +2,6 @@
 # Read Edges from file
 #
 function StrFileRead(fname)
-  fid = open(fname,"r");
-  uv = split(readall(fid));
-  # ut = int(uv[1:2:end])';   # makt it horizontal vector
-  # vt = int(uv[2:2:end])';   # makt it horizontal vector
-  ut = [parse(Int64,s) for s=uv[1:2:end]] # makt it horizontal vector
-  vt = [parse(Int64,s) for s=uv[2:2:end]] # makt it horizontal vector
-  close(fid)
-  return ut,vt
+    uv = readdlm(fname, Int)
+    return uv[1:2:end], uv[2:2:end]
 end
-

--- a/code/Julia/StrFileRead.jl
+++ b/code/Julia/StrFileRead.jl
@@ -2,6 +2,7 @@
 # Read Edges from file
 #
 function StrFileRead(fname)
-    uv = readdlm(fname, Int)
-    return uv[1:2:end], uv[2:2:end]
+    uv = readdlm(fname, ' ', Int)::Matrix{Int}
+    n = size(uv, 2)
+    return uv[1:2:n], uv[2:2:n]
 end

--- a/code/Julia/StrFileWrite.jl
+++ b/code/Julia/StrFileWrite.jl
@@ -1,9 +1,17 @@
-function StrFileWrite(edgeStr,fname)
-#
-# Write edgeStr to fname
-#
-  fid = open(fname,"w");
-  write(fid,edgeStr);    # space separated
-  close(fid);
-end
+function writeuv(fname, u, v)
+    n = length(u)
+    f = IOBuffer()#20n)
+    for j in 1:n-1
+         write(f, string(u[j]))
+         write(f, ' ')
+         write(f, string(v[j]))
+         write(f, ' ')
+    end
+    write(f, string(u[n]))
+    write(f, ' ')
+    write(f, string(v[n]))
 
+    open(fname, "w") do g
+        write(g, takebuf_string(f))
+    end
+end


### PR DESCRIPTION
I've made a pass over Julia code in the repository to make it more idiomatic and eliminate the use of inefficient MATLAB-like commands.

This pull request makes several code changes to improve the speed of the Julia code. In many cases the improvement is 10x or greater.

Summary of changes:
- In-place mutating operations are used where possible, e.g. `scale!(a, b)` instead of `a = a.*b`, and array views `sub(A, :, 1)` in lieu of copies `A[:, 1]`.
- Simplified file I/O code
- Avoid vectorized operations in favor of writing out explicit for loops
- Use `scale!` instead of sparse matmul for diagonal x sparse in K2
- Remove type instability - don't reuse `i` for scalar and vector indexes, and so on

I also removed semicolons in the lines that I touched - they are mostly unnecessary in Julia and they are not needed to suppress output or to end a statement.

The one thing I didn't change is to rewrite `b*A` into `(A*b)'`, since it looks like you are explicitly benchmarking "vecmat" operations, which are not natural in Julia and have to be simulated with row matrix x matrix operations.

after:

```
scale   k0-edges-per-sec    k1-edges-per-sec    k2-edges-per-sec    k3-edges-per-sec
16384   1083001.8028436995  29322.508330906006  1805017.561022902   3871300.523289533
32768   1773909.8612562993  990937.6142354382   1996761.7214538117  362220034.74296784
65536   1859974.6932642444  1146452.2013610622  2055791.2561303037  250749012.0463673
131072  1717525.4529797793  744660.0460030059   1462645.891735659   180865515.28740132
262144  1413516.7398048237  745206.9510094854   1340359.7984361553  243721324.43513978
524288  1533899.1827641048  746738.5727661067   1219988.3415962423  216147601.31171572
1048576 1591695.317053853   764024.3808543442   1171522.541363742   143490752.44497326
```

before:

```
scale   k0-edges-per-sec    k1-edges-per-sec    k2-edges-per-sec    k3-edges-per-sec
16384   32715.994262927718  49560.807274887644  49775.781129473966  1756696.9662404153
32768   196089.1794055616   175006.01276075182  1184763.695901588   103459555.1693784
65536   194237.61984653943  213860.2440404617   1002932.0642994292  81663683.21827883
131072  217681.09766689962  222660.69418494092  989774.7341211278   54229594.55421871
262144  218191.06603552564  221851.16735839212  581347.1172400148   59082335.998872004
524288  206518.05565072008  221310.01817073236  986361.732802518    91955407.56957653
1048576 218349.76349001713  235138.21278212997  987605.8729298214   91022591.21137235
```
